### PR TITLE
Fix Storybook global

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,20 +2,11 @@
   "name": "vite-plugin-storybook-nextjs",
   "version": "0.0.5",
   "description": "",
-  "keywords": [
-    "vite-plugin",
-    "nextjs",
-    "storybook",
-    "vitest"
-  ],
+  "keywords": ["vite-plugin", "nextjs", "storybook", "vitest"],
   "author": "Storybook Bot <storybookbot@gmail.com>",
   "license": "MIT",
-  "sideEffects": [
-    "./src/polyfills/promise-with-resolvers.ts"
-  ],
-  "files": [
-    "dist"
-  ],
+  "sideEffects": ["./src/polyfills/promise-with-resolvers.ts"],
+  "files": ["dist"],
   "type": "module",
   "exports": {
     ".": {

--- a/src/mocks/storybook.global.ts
+++ b/src/mocks/storybook.global.ts
@@ -1,5 +1,8 @@
+import { createRequire } from "node:module";
 // @ts-ignore no types
 import moduleAlias from "module-alias";
+
+const require = createRequire(import.meta.url);
 
 // I only need this in non-browser mode
 moduleAlias.addAliases({


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.6--canary.7.07b4e0e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@0.0.6--canary.7.07b4e0e.0
  # or 
  yarn add vite-plugin-storybook-nextjs@0.0.6--canary.7.07b4e0e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
