### PR TITLE
fix: readme typo about vitest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ When testing components that rely on Next.js Server Actions, you need to ensure 
 
    export default defineConfig({
      plugins: [nextjs()],
-     vitest: {
+     test: {
        environment: "jsdom", // 👈 Add this
      },
    });

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a Vite plugin that allows you to use Next.js features in Vite. It is the basis for `@storybook/experimental-nextjs-vite` and should be used when running portable stories in Vitest.
 
 ## Features
-
 - **Next.js Integration**: Seamlessly integrate Next.js features into your Vite project.
 - **Storybook Compatibility**: Acts as the foundation for [the `@storybook/experimental-nextjs-vite` framework](https://storybook.js.org/docs/get-started/frameworks/nextjs#with-vite), enabling you to use Storybook with Next.js in a Vite environment.
 - **Portable Stories**: Ideal for running portable stories in Vitest, ensuring your components are tested in an environment that closely mirrors production.
@@ -116,7 +115,7 @@ When testing components that rely on Next.js Server Actions, you need to ensure 
 
    ```ts
    // vitest.config.ts
-   import { defineConfig } from "vite";
+   import { defineConfig } from "vitest/config";
    import nextjs from "vite-plugin-storybook-nextjs";
 
    export default defineConfig({


### PR DESCRIPTION
The `vitest` property was mistakenly written in `defineConfig` in `vitest.config.ts` in REAME, so it has been fixed to use the `test` property. Also, to make it safe to specify the `test` property, it change to `vitest/config` to match [the example code](https://github.com/storybookjs/vite-plugin-storybook-nextjs/blob/main/example/vitest.config.mts#L3).