### PR TITLE
fix: fixes an issue where the next-font plugin would not work on windows

### DIFF
--- a/src/plugins/next-font/plugin.ts
+++ b/src/plugins/next-font/plugin.ts
@@ -67,7 +67,7 @@ export function vitePluginNextFont() {
 
       let fontFaceDeclaration: FontFaceDeclaration | undefined;
 
-      const pathSep = path.sep;
+      const pathSep = path.posix.sep;
 
       if (
         sourceWithoutQuery.endsWith(


### PR DESCRIPTION
Uses the `path.posix.sep` instead of the platform specific one. This matches vite's behavior of using unix path separators regardless of the platform.