### PR TITLE
fix: Aliases to react & react-dom use full path resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,11 +58,11 @@ function VitePlugin({ dir = process.cwd() }: VitePluginOptions = {}): Plugin[] {
               alias: [
                 {
                   find: /^react$/,
-                  replacement: "next/dist/compiled/react",
+                  replacement: require.resolve("next/dist/compiled/react"),
                 },
                 {
                   find: /^react-dom$/,
-                  replacement: "next/dist/compiled/react-dom",
+                  replacement: require.resolve("next/dist/compiled/react-dom"),
                 },
                 {
                   find: /^react-dom\/server$/,


### PR DESCRIPTION
Was having issues using the [experimental plugin](https://github.com/storybookjs/storybook/tree/next/code/frameworks/experimental-nextjs-vite) in a monorepo. `react` and `react-dom` imports were being overwritten in components whose package didn't have any next dependencies.