### PR TITLE
fix: Export additional cache utilities from the cache module

### DIFF
--- a/src/plugins/next-mocks/alias/cache/index.ts
+++ b/src/plugins/next-mocks/alias/cache/index.ts
@@ -29,3 +29,4 @@ const cacheExports = {
 };
 
 export default cacheExports;
+export { unstable_cache, revalidateTag, revalidatePath, unstable_noStore };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.13--canary.24.651b0b1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@1.0.13--canary.24.651b0b1.0
  # or 
  yarn add vite-plugin-storybook-nextjs@1.0.13--canary.24.651b0b1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
