### PR TITLE
Add Vite 6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@storybook/test": "^8.3.0",
     "next": "^14.1.0 || ^15.0.0",
     "storybook": "^8.3.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.1",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.1--canary.30.8993756.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@1.1.1--canary.30.8993756.0
  # or 
  yarn add vite-plugin-storybook-nextjs@1.1.1--canary.30.8993756.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
