### PR TITLE
fix: Add styled-jsx/style alias to next-mocks plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "image-size": "^1.1.1",
     "magic-string": "^0.30.11",
     "module-alias": "^2.2.3",
-    "ts-dedent": "^2.2.0"
+    "ts-dedent": "^2.2.0",
+    "styled-jsx": "^5.1.6"
   },
   "optionalDependencies": {
     "sharp": "^0.33.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       module-alias:
         specifier: ^2.2.3
         version: 2.2.3
+      styled-jsx:
+        specifier: ^5.1.6
+        version: 5.1.6(react@18.3.1)
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0

--- a/src/plugins/next-mocks/plugin.ts
+++ b/src/plugins/next-mocks/plugin.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import path, { resolve } from "node:path";
 import type { Plugin } from "vite";
 import { VITEST_PLUGIN_NAME, getExecutionEnvironment } from "../../utils";
 
@@ -39,6 +40,9 @@ export const getAlias = (env: Env) => ({
   "@opentelemetry/api": require.resolve(
     "next/dist/compiled/@opentelemetry/api",
   ),
+  "styled-jsx/style.js": resolve("styled-jsx/style"),
+  "styled-jsx/style": require.resolve("styled-jsx/style"),
+  "styled-jsx": path.dirname(require.resolve("styled-jsx/package.json")),
   "next/dynamic": getEntryPoint("dynamic", env),
 });
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30303

PNPM or yarn pnp are strict about accessing dependencies. A module is only allowed to access dependencies if they are defined in its package.json. The user usually doesn't install `styled-jsx` directly. The transformed button element has references to `styled-jsx/style`, which cannot be resolved. Therefore, we have to alias `styled-jsx` and access the `styled-jsx` module provided by this plugin's package.json's dependencies.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.2--canary.31.ce898c2.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@1.1.2--canary.31.ce898c2.0
  # or 
  yarn add vite-plugin-storybook-nextjs@1.1.2--canary.31.ce898c2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
