### PR TITLE
Fix: Add missing react aliases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,24 @@ function VitePlugin({ dir = process.cwd() }: VitePluginOptions = {}): Plugin[] {
                   replacement: require.resolve("next/dist/compiled/react"),
                 },
                 {
+                  find: /^react\/jsx-runtime$/,
+                  replacement: require.resolve(
+                    "next/dist/compiled/react/jsx-runtime",
+                  ),
+                },
+                {
+                  find: /^react\/jsx-dev-runtime$/,
+                  replacement: require.resolve(
+                    "next/dist/compiled/react/jsx-dev-runtime",
+                  ),
+                },
+                {
+                  find: /^react\/compiler-runtime$/,
+                  replacement: require.resolve(
+                    "next/dist/compiled/react/compiler-runtime",
+                  ),
+                },
+                {
                   find: /^react-dom$/,
                   replacement: require.resolve("next/dist/compiled/react-dom"),
                 },


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30897

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.3--canary.35.2184b9c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@1.1.3--canary.35.2184b9c.0
  # or 
  yarn add vite-plugin-storybook-nextjs@1.1.3--canary.35.2184b9c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
