### PR TITLE
Fix: Add next > styled-jsx to optimizeDeps for pnpm compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,14 @@ function VitePlugin({ dir = process.cwd() }: VitePluginOptions = {}): Plugin[] {
   const resolvedDir = resolve(dir);
   const nextConfigResolver = Promise.withResolvers<NextConfigComplete>();
 
+  let styledJsxIsInstalled: boolean;
+  try {
+    require.resolve("styled-jsx");
+    styledJsxIsInstalled = true;
+  } catch (e) {
+    styledJsxIsInstalled = false;
+  }
+
   return [
     {
       name: "vite-plugin-storybook-nextjs",
@@ -117,7 +125,7 @@ function VitePlugin({ dir = process.cwd() }: VitePluginOptions = {}): Plugin[] {
               "next/image",
               "next/legacy/image",
               "react/jsx-dev-runtime",
-              "styled-jsx/style",
+              ...(styledJsxIsInstalled ? ["styled-jsx/style"] : []),
             ],
           },
           test: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,14 +36,6 @@ function VitePlugin({ dir = process.cwd() }: VitePluginOptions = {}): Plugin[] {
   const resolvedDir = resolve(dir);
   const nextConfigResolver = Promise.withResolvers<NextConfigComplete>();
 
-  let styledJsxIsInstalled: boolean;
-  try {
-    require.resolve("styled-jsx");
-    styledJsxIsInstalled = true;
-  } catch (e) {
-    styledJsxIsInstalled = false;
-  }
-
   return [
     {
       name: "vite-plugin-storybook-nextjs",
@@ -125,7 +117,10 @@ function VitePlugin({ dir = process.cwd() }: VitePluginOptions = {}): Plugin[] {
               "next/image",
               "next/legacy/image",
               "react/jsx-dev-runtime",
-              ...(styledJsxIsInstalled ? ["styled-jsx/style"] : []),
+              // Required for pnpm setups, since styled-jsx is a transitive dependency of Next.js and not directly listed.
+              // Refer to this pnpm issue for more details:
+              // https://github.com/vitejs/vite/issues/16293
+              "next > styled-jsx/style",
             ],
           },
           test: {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30896


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.4--canary.36.b5ef3c1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@1.1.4--canary.36.b5ef3c1.0
  # or 
  yarn add vite-plugin-storybook-nextjs@1.1.4--canary.36.b5ef3c1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
