### PR TITLE
Fix: Remove React compiler-runtime alias that doesn't exist in Next 14

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,12 +73,6 @@ function VitePlugin({ dir = process.cwd() }: VitePluginOptions = {}): Plugin[] {
                   ),
                 },
                 {
-                  find: /^react\/compiler-runtime$/,
-                  replacement: require.resolve(
-                    "next/dist/compiled/react/compiler-runtime",
-                  ),
-                },
-                {
                   find: /^react-dom$/,
                   replacement: require.resolve("next/dist/compiled/react-dom"),
                 },


### PR DESCRIPTION
This PR removes the React compiler-runtime alias configuration that doesn't exist in Next 14 and was causing Vite to crash. This dependency is only needed for Node and not for the browser build.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.5--canary.38.08e5898.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@1.1.5--canary.38.08e5898.0
  # or 
  yarn add vite-plugin-storybook-nextjs@1.1.5--canary.38.08e5898.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
