### PR TITLE
Fix JSON.parse error in vitePluginNextFont

### DIFF
--- a/src/plugins/next-font/plugin.ts
+++ b/src/plugins/next-font/plugin.ts
@@ -28,7 +28,7 @@ type FontOptions = {
   source: string;
 };
 
-const includePattern = /next(\\|\/|\\\\).*(\\|\/|\\\\)target\.css.*$/;
+const includePattern = /next(\\|\/|\\\\).*(\\|\/|\\\\)target\.css\?.*$/;
 
 const virtualModuleId = "virtual:next-font";
 


### PR DESCRIPTION
resolved: https://github.com/storybookjs/vite-plugin-storybook-nextjs/issues/43

When using next/font, the file `next/font/google/target.css` gets processed by `vitePluginNextFont`. However, this file doesn't contain query parameters, causing `JSON.parse` to fail.

Changes:
Added a check to skip execution when no query parameters are present

Root Cause:
The plugin was attempting to parse query parameters on all processed files, but `next/font/google/target.css` doesn't include the expected query string format, leading to parsing failures.