### PR TITLE
Fix: Resolve dynamic require issues when using with Vitest

### DIFF
--- a/src/plugins/next-env/plugin.ts
+++ b/src/plugins/next-env/plugin.ts
@@ -7,6 +7,7 @@ import { createRequire } from "node:module";
 import type { DefineEnvOptions } from "next/dist/build/define-env";
 import * as NextUtils from "../../utils/nextjs";
 
+// Require is not available in Vitest ESM
 const require = createRequire(import.meta.url);
 
 export function vitePluginNextEnv(

--- a/src/plugins/next-env/plugin.ts
+++ b/src/plugins/next-env/plugin.ts
@@ -3,14 +3,10 @@ import type { Env } from "@next/env";
 import type { NextConfigComplete } from "next/dist/server/config-shared.js";
 import type { Plugin } from "vite";
 
-import { createRequire } from "node:module";
 import type { DefineEnvOptions } from "next/dist/build/define-env";
 import * as NextUtils from "../../utils/nextjs";
 
-// Require is not available in Vitest ESM
-const require = createRequire(import.meta.url);
-
-export function vitePluginNextEnv(
+export async function vitePluginNextEnv(
   rootDir: string,
   nextConfigResolver: PromiseWithResolvers<NextConfigComplete>,
 ) {
@@ -24,12 +20,14 @@ export function vitePluginNextEnv(
 
   try {
     // Next.js >= 15.4.0
-    getDefineEnv = require("next/dist/build/define-env.js").getDefineEnv;
+    getDefineEnv = (await import("next/dist/build/define-env.js")).getDefineEnv;
     isNext1540 = true;
   } catch (error) {
     // Next.js < 15.4.0
     getDefineEnv =
-      require("next/dist/build/webpack/plugins/define-env-plugin.js").getDefineEnv;
+      // @ts-expect-error - TODO: Ignoring because types are for >= 15.4.0
+      (await import("next/dist/build/webpack/plugins/define-env-plugin.js"))
+        .getDefineEnv;
   }
 
   return {


### PR DESCRIPTION
Fixes https://github.com/storybookjs/vite-plugin-storybook-nextjs/pull/45#issuecomment-3004913330

## Problem

This package is built with esbuild (via tsup), but esbuild converts dynamic `require()` calls into code that causes runtime errors when targeting ESM. As a result, when Vitest loads this module in ESM mode, the following error occurs:

```
[Error: Dynamic require of "next/dist/build/webpack/plugins/define-env-plugin.js" is not supported]
```

This is a known limitation of esbuild when outputting ESM code.
Reference: https://github.com/evanw/esbuild/issues/1921

## Solution

Replaced dynamic `require()` calls with dynamic `import()` statements to properly handle module loading in ESM environments. Dynamic `import()` works in both ESM and CommonJS environments, making this change backwards compatible.

With this fix, we can now run Vitest without errors in our repository (Next.js 15.3.4).