### PR TITLE
feat: Use the same React release channel as Next.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { vitePluginNextFont } from "./plugins/next-font/plugin";
 import { vitePluginNextSwc } from "./plugins/next-swc/plugin";
 
 import "./polyfills/promise-with-resolvers";
+import { needsExperimentalReact } from "next/dist/lib/needs-experimental-react.js";
 import nextServerConfig from "next/dist/server/config.js";
 import {
   PHASE_DEVELOPMENT_SERVER,
@@ -53,7 +54,12 @@ function VitePlugin({
               ? PHASE_TEST
               : PHASE_PRODUCTION_BUILD;
 
-        nextConfigResolver.resolve(await loadConfig(phase, resolvedDir));
+        const nextConfig = await loadConfig(phase, resolvedDir);
+        nextConfigResolver.resolve(nextConfig);
+
+        const bundledReactChannel = needsExperimentalReact(nextConfig)
+          ? "-experimental"
+          : "";
 
         const executionEnvironment = getExecutionEnvironment(config);
 
@@ -63,46 +69,50 @@ function VitePlugin({
               alias: [
                 {
                   find: /^react$/,
-                  replacement: require.resolve("next/dist/compiled/react"),
+                  replacement: require.resolve(
+                    `next/dist/compiled/react${bundledReactChannel}`,
+                  ),
                 },
                 {
                   find: /^react\/jsx-runtime$/,
                   replacement: require.resolve(
-                    "next/dist/compiled/react/jsx-runtime",
+                    `next/dist/compiled/react${bundledReactChannel}/jsx-runtime`,
                   ),
                 },
                 {
                   find: /^react\/jsx-dev-runtime$/,
                   replacement: require.resolve(
-                    "next/dist/compiled/react/jsx-dev-runtime",
+                    `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime`,
                   ),
                 },
                 {
                   find: /^react-dom$/,
-                  replacement: require.resolve("next/dist/compiled/react-dom"),
+                  replacement: require.resolve(
+                    `next/dist/compiled/react-dom${bundledReactChannel}`,
+                  ),
                 },
                 {
                   find: /^react-dom\/server$/,
                   replacement: require.resolve(
-                    "next/dist/compiled/react-dom/server.browser.js",
+                    `next/dist/compiled/react-dom${bundledReactChannel}/server.browser.js`,
                   ),
                 },
                 {
                   find: /^react-dom\/test-utils$/,
                   replacement: require.resolve(
-                    "next/dist/compiled/react-dom/cjs/react-dom-test-utils.production.js",
+                    `next/dist/compiled/react-dom${bundledReactChannel}/cjs/react-dom-test-utils.production.js`,
                   ),
                 },
                 {
                   find: /^react-dom\/client$/,
                   replacement: require.resolve(
-                    "next/dist/compiled/react-dom/client.js",
+                    `next/dist/compiled/react-dom${bundledReactChannel}/client.js`,
                   ),
                 },
                 {
                   find: /^react-dom\/cjs\/react-dom\.development\.js$/,
                   replacement: require.resolve(
-                    "next/dist/compiled/react-dom/cjs/react-dom.development.js",
+                    `next/dist/compiled/react-dom${bundledReactChannel}/cjs/react-dom.development.js`,
                   ),
                 },
               ],
@@ -137,33 +147,37 @@ function VitePlugin({
           test: {
             alias: {
               "react/jsx-dev-runtime": require.resolve(
-                "next/dist/compiled/react/jsx-dev-runtime.js",
+                `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime.js`,
               ),
               "react/jsx-runtime": require.resolve(
-                "next/dist/compiled/react/jsx-runtime.js",
+                `next/dist/compiled/react${bundledReactChannel}/jsx-runtime.js`,
               ),
 
-              react: require.resolve("next/dist/compiled/react"),
+              react: require.resolve(
+                `next/dist/compiled/react${bundledReactChannel}`,
+              ),
 
               "react-dom/server": require.resolve(
                 executionEnvironment === "node"
-                  ? "next/dist/compiled/react-dom/server.js"
-                  : "next/dist/compiled/react-dom/server.browser.js",
+                  ? `next/dist/compiled/react-dom${bundledReactChannel}/server.js`
+                  : `next/dist/compiled/react-dom${bundledReactChannel}/server.browser.js`,
               ),
 
               "react-dom/test-utils": require.resolve(
-                "next/dist/compiled/react-dom/cjs/react-dom-test-utils.production.js",
+                `next/dist/compiled/react-dom${bundledReactChannel}/cjs/react-dom-test-utils.production.js`,
               ),
 
               "react-dom/cjs/react-dom.development.js": require.resolve(
-                "next/dist/compiled/react-dom/cjs/react-dom.development.js",
+                `next/dist/compiled/react-dom${bundledReactChannel}/cjs/react-dom.development.js`,
               ),
 
               "react-dom/client": require.resolve(
-                "next/dist/compiled/react-dom/client.js",
+                `next/dist/compiled/react-dom${bundledReactChannel}/client.js`,
               ),
 
-              "react-dom": require.resolve("next/dist/compiled/react-dom"),
+              "react-dom": require.resolve(
+                `next/dist/compiled/react-dom${bundledReactChannel}`,
+              ),
             },
           },
         };

--- a/src/plugins/next-image/alias/image-context.tsx
+++ b/src/plugins/next-image/alias/image-context.tsx
@@ -1,6 +1,6 @@
-import { createContext } from "next/dist/compiled/react";
 import type { ImageProps, StaticImageData } from "next/image";
 import type { ImageProps as LegacyImageProps } from "next/legacy/image";
+import { createContext } from "react";
 
 // StaticRequire needs to be in scope for the TypeScript compiler to work.
 // See: https://github.com/microsoft/TypeScript/issues/5711

--- a/src/plugins/next-image/alias/next-image.tsx
+++ b/src/plugins/next-image/alias/next-image.tsx
@@ -5,7 +5,7 @@ import type * as _NextImage from "next/image";
 import { defaultLoader } from "sb-original/default-loader";
 import { ImageContext } from "sb-original/image-context";
 
-import React from "next/dist/compiled/react";
+import React from "react";
 
 const OriginalNextImage = NextImageNamespace.default;
 const { getImageProps: originalGetImageProps } = NextImageNamespace;

--- a/src/plugins/next-image/alias/next-legacy-image.tsx
+++ b/src/plugins/next-image/alias/next-legacy-image.tsx
@@ -3,8 +3,8 @@ import OriginalNextLegacyImage from "next/legacy/image";
 import { defaultLoader } from "sb-original/default-loader";
 import { ImageContext } from "sb-original/image-context";
 
-import React from "next/dist/compiled/react";
 import type * as _NextLegacyImage from "next/legacy/image";
+import React from "react";
 
 function NextLegacyImage({ loader, ...props }: _NextLegacyImage.ImageProps) {
   const imageParameters = React.useContext(ImageContext);


### PR DESCRIPTION
closes #52 

The plugin was hardcoded to use Next.js's stable React compiled modules, but Next.js may use experimental React features depending on its configuration. This mismatch could cause issues when Next.js applications use experimental React features that require the experimental React channel.

## Changes

- Import needsExperimentalReact from Next.js to detect required React channel
- Add bundledReactChannel variable that resolves to -experimental or empty string
- Update all React module aliases to use the dynamic channel
