### PR TITLE
docs: Update links to actions docs page

### DIFF
--- a/example/src/stories/Button.stories.ts
+++ b/example/src/stories/Button.stories.ts
@@ -16,7 +16,7 @@ const meta = {
   argTypes: {
     backgroundColor: { control: "color" },
   },
-  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#story-args
   args: { onClick: fn() },
 } satisfies Meta<typeof Button>;
 


### PR DESCRIPTION
Goes with https://github.com/storybookjs/storybook/pull/32083
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.6--canary.55.48131ce.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-storybook-nextjs@2.0.6--canary.55.48131ce.0
  # or 
  yarn add vite-plugin-storybook-nextjs@2.0.6--canary.55.48131ce.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
