### PR TITLE
Transform Windows-style backslashes in image paths

### DIFF
--- a/src/plugins/next-image/plugin.ts
+++ b/src/plugins/next-image/plugin.ts
@@ -54,7 +54,7 @@ export function vitePluginNextImage(
             : path.join(path.dirname(importer), source)
           : source;
 
-        return `${virtualImage}?imagePath=${imagePath}`;
+        return `${virtualImage}?imagePath=${imagePath.replace(/\\/g, "/")}`;
       }
 
       if (id === "next/image" && importer !== virtualNextImage) {


### PR DESCRIPTION
Fixes https://github.com/storybookjs/storybook/issues/32355 & https://github.com/storybookjs/storybook/issues/32354

## Problem
On Windows machine, an image imports includes backslashes in the imagePath query-param. Eg. `virtual:next-image?imagePath=C:\\codebase\\images\\sprite.svg`.


## Solution
Transform the imagePath to use forwardSlash when generating resolveId