### PR TITLE
Streamline release tooling: changesets + pkg.pr.new

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - next
 
 env:
   TURBO_ENV_MODE: loose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - next
 
 jobs:
   release:


### PR DESCRIPTION
Summary:
- restrict release workflow pushes to main only
- restrict pkg.pr.new preview pushes to main only
- keep existing Changesets, bot-app auth, and OIDC setup intact

Validation:
- pnpm build