### PR TITLE
Handle ambiguous default import from CJS module in next/image mocks

### DIFF
--- a/.changeset/fix-next-image-cjs-interop.md
+++ b/.changeset/fix-next-image-cjs-interop.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-storybook-nextjs": patch
+---
+
+Handle ambiguous default import from CJS module in next/image mocks. Defensively unwrap `__esModule` objects to extract the real default export and `getImageProps`, following Rolldown's recommendation for CJS interop.

--- a/src/plugins/next-image/alias/next-image.tsx
+++ b/src/plugins/next-image/alias/next-image.tsx
@@ -7,8 +7,18 @@ import { ImageContext } from "sb-original/image-context";
 
 import React from "next/dist/compiled/react";
 
-const OriginalNextImage = NextImageNamespace.default;
-const { getImageProps: originalGetImageProps } = NextImageNamespace;
+// Handle ambiguous default import from CJS module.
+// See: https://rolldown.rs/in-depth/bundling-cjs#recommendations-for-library-authors
+const _raw = NextImageNamespace.default;
+const OriginalNextImage =
+  typeof _raw === "object" && _raw !== null && "__esModule" in _raw
+    ? (_raw as Record<string, typeof _raw>).default
+    : _raw;
+const originalGetImageProps =
+  NextImageNamespace.getImageProps ??
+  (typeof _raw === "object" && _raw !== null && "getImageProps" in _raw
+    ? (_raw as Record<string, typeof NextImageNamespace.getImageProps>).getImageProps
+    : undefined);
 
 const MockedNextImage = React.forwardRef<
   HTMLImageElement,

--- a/src/plugins/next-image/alias/next-image.tsx
+++ b/src/plugins/next-image/alias/next-image.tsx
@@ -17,7 +17,8 @@ const OriginalNextImage =
 const originalGetImageProps =
   NextImageNamespace.getImageProps ??
   (typeof _raw === "object" && _raw !== null && "getImageProps" in _raw
-    ? (_raw as Record<string, typeof NextImageNamespace.getImageProps>).getImageProps
+    ? (_raw as Record<string, typeof NextImageNamespace.getImageProps>)
+        .getImageProps
     : undefined);
 
 const MockedNextImage = React.forwardRef<

--- a/src/plugins/next-image/alias/next-legacy-image.tsx
+++ b/src/plugins/next-image/alias/next-legacy-image.tsx
@@ -1,10 +1,18 @@
 // @ts-ignore import is aliased in webpack config
-import OriginalNextLegacyImage from "next/legacy/image";
+import * as _NextLegacyImageNamespace from "next/legacy/image";
 import { defaultLoader } from "sb-original/default-loader";
 import { ImageContext } from "sb-original/image-context";
 
 import React from "next/dist/compiled/react";
 import type * as _NextLegacyImage from "next/legacy/image";
+
+// Handle ambiguous default import from CJS module.
+// See: https://rolldown.rs/in-depth/bundling-cjs#recommendations-for-library-authors
+const _rawLegacy = _NextLegacyImageNamespace.default;
+const OriginalNextLegacyImage =
+  typeof _rawLegacy === "object" && _rawLegacy !== null && "__esModule" in _rawLegacy
+    ? (_rawLegacy as Record<string, typeof _rawLegacy>).default
+    : _rawLegacy;
 
 function NextLegacyImage({ loader, ...props }: _NextLegacyImage.ImageProps) {
   const imageParameters = React.useContext(ImageContext);

--- a/src/plugins/next-image/alias/next-legacy-image.tsx
+++ b/src/plugins/next-image/alias/next-legacy-image.tsx
@@ -10,7 +10,9 @@ import type * as _NextLegacyImage from "next/legacy/image";
 // See: https://rolldown.rs/in-depth/bundling-cjs#recommendations-for-library-authors
 const _rawLegacy = _NextLegacyImageNamespace.default;
 const OriginalNextLegacyImage =
-  typeof _rawLegacy === "object" && _rawLegacy !== null && "__esModule" in _rawLegacy
+  typeof _rawLegacy === "object" &&
+  _rawLegacy !== null &&
+  "__esModule" in _rawLegacy
     ? (_rawLegacy as Record<string, typeof _rawLegacy>).default
     : _rawLegacy;
 


### PR DESCRIPTION
## Summary
- Follow [Rolldown's recommendation for handling CJS interop](https://rolldown.rs/in-depth/bundling-cjs#recommendations-for-library-authors) in `next/image` and `next/legacy/image` mock aliases
- Defensively unwrap `__esModule` objects to extract the real default export and `getImageProps`
- This issue could not be reproduced in the example project — Vite's static import interop (`needsInterop`) correctly handles the unwrapping in simple setups, but the issue appears in more complex environments
- Upgrading Vite/Next.js versions in the example project introduces unrelated issues (e.g. vite-plugin-svgr compatibility), so version upgrades should be handled in a separate PR

Closes #114

## Validation
- pnpm check
- pnpm build