### PR TITLE
fix: pre-bundle Next.js 16 navigation/redirect-error for Vite dev mode

### DIFF
--- a/.changeset/nextjs16-optimizedeps-navigation.md
+++ b/.changeset/nextjs16-optimizedeps-navigation.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-storybook-nextjs": patch
+---
+
+Fix missing Next.js 16 internal exports (`ServerInsertedHTMLContext`, `RedirectStatusCode`) in Vite dev mode by adding `next/navigation` and `next/dist/client/components/redirect-error` to `optimizeDeps.include` for Next.js 16+. See [storybookjs/storybook#34688](https://github.com/storybookjs/storybook/issues/34688).

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,17 @@ function VitePlugin({
                 ? ["@emotion/react/jsx-dev-runtime"]
                 : []),
               ...(isNext16orNewer ? [] : ["next/config"]),
+              // Next.js 16 ships internal re-export chains that Vite's esbuild
+              // pre-bundler fails to resolve in dev mode, causing missing exports
+              // like ServerInsertedHTMLContext and RedirectStatusCode. Forcing
+              // these modules to be pre-bundled fixes the resolution.
+              // See: https://github.com/storybookjs/storybook/issues/34688
+              ...(isNext16orNewer
+                ? [
+                    "next/navigation",
+                    "next/dist/client/components/redirect-error",
+                  ]
+                : []),
             ],
           },
           test: {


### PR DESCRIPTION
## What

Adds `next/navigation` and `next/dist/client/components/redirect-error` to `optimizeDeps.include` for Next.js 16+.

## Why

Next.js 16 ships internal re-export chains that Vite's esbuild pre-bundler fails to resolve in dev mode. This surfaces as missing exports such as `ServerInsertedHTMLContext` and `RedirectStatusCode` when running Storybook with `@storybook/nextjs-vite` on Next.js 16. Forcing these modules to be pre-bundled fixes the resolution.

The entries are gated behind the existing `isNext16orNewer` check so Next.js < 16 setups are unaffected.

## Context

This supersedes storybookjs/storybook#34774, which proposed the same fix in Storybook's `@storybook/nextjs-vite` preset. The actual `optimizeDeps` config lives here in the Vite plugin, so this is the correct single source of truth. Once released, the fix flows into Storybook automatically.

Fixes the root cause described in storybookjs/storybook#34688.

Original contribution by @jshaofa-ui.

## Checklist

- [x] Changeset added (`patch`)
- [x] `pnpm build` passes
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)