### PR TITLE
docs: add AGENTS.md for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions
+
+Canonical agent guidance for `vite-plugin-storybook-nextjs`. `CLAUDE.md` symlinks here —
+keep instructions here, don't duplicate.
+
+This plugin aliases Next.js modules to Storybook-friendly mocks so portable stories run
+under Vitest. It backs `@storybook/nextjs-vite` / `@storybook/experimental-nextjs-vite`.
+
+## Quick start
+
+- **pnpm only** (pinned via `packageManager`). Build: `pnpm build` (or `pnpm dev` to watch;
+  restart Storybook after plugin changes).
+- **Lint/format:** `pnpm check` / `pnpm check:write` — Biome `1.8.1`, `organizeImports` on
+  (let Biome sort imports, don't hand-order).
+- **Tests:** no root runner — `./example` is the harness: `pnpm test:all` or `pnpm storybook`.
+- User-facing change → `pnpm changeset`. Tests/docs-only → no changeset.
+
+## Deep dives — read only when the task matches
+
+| If you are… | Read |
+| --- | --- |
+| Adding/changing a Next.js mock, or writing a story that overrides or asserts on a mock | [`docs/agents/mocks.md`](docs/agents/mocks.md) |
+
+Don't load deep-dive docs unless the task matches — this file is meant to stay scannable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/agents/mocks.md
+++ b/docs/agents/mocks.md
@@ -1,0 +1,53 @@
+# Next.js mocks — authoring & testing
+
+Deep dive referenced from [`AGENTS.md`](../../AGENTS.md). Read this when adding/changing a
+Next.js mock or writing a story that overrides or asserts on one.
+
+## Wiring a mock — five coordinated edits
+
+Miss any one and the mock silently won't resolve:
+
+1. **Alias module:** `src/plugins/next-mocks/alias/<name>/index.tsx` — the implementation.
+   Use `fn().mockName(...)` from `storybook/test` for spies.
+2. **Alias registration:** `getAlias()` in `src/plugins/next-mocks/plugin.ts` — register
+   **all four** specifiers, each mapping to `getEntryPoint("<name>", env)`:
+   - `next/<name>`
+   - `@storybook/nextjs/<name>.mock`
+   - `@storybook/nextjs-vite/<name>.mock`
+   - `@storybook/experimental-nextjs-vite/<name>.mock`
+3. **Build entry:** add the alias module path to `entry` in `tsup.config.ts`.
+4. **Package exports:** add `./browser/mocks/<name>` (→ `…/index.js`) and
+   `./node/mocks/<name>` (→ `…/index.cjs`) to `exports` in `package.json`.
+5. **Changeset:** `pnpm changeset` (a new mock is user-facing).
+
+## Stories that override / assert on a mock
+
+Stories live at `example/src/app/components/<Name>/<Name>.stories.tsx` and run via
+Storybook Vitest (`example/.storybook/vitest.setup.ts` → `setProjectAnnotations`).
+
+- The **component under test** imports the real specifier (`import Link from "next/link"`);
+  the Vite plugin alias swaps it for the mock at build time.
+- To **override or assert on the spy**, import it from `@storybook/nextjs-vite/<name>.mock`
+  (e.g. `@storybook/nextjs-vite/link.mock`). Canonical example: `Cache.stories.tsx`.
+- `expect` / `within` come from `storybook/test`; jest-dom matchers
+  (`toBeInTheDocument`, …) are available there even though existing stories rarely use them.
+- Override a hook mock per-story with `beforeEach()` + `mockReturnValue(...)`. Storybook
+  auto-resets `fn()` mocks between stories, so overrides don't leak.
+
+### The non-obvious part
+
+The bridge from import specifier to mock is the **plugin alias** (step 2), **not**
+`package.json` exports. So:
+
+- Do **not** import from `vite-plugin-storybook-nextjs/...` or a `./<name>.mock` subpath
+  of this package — those don't exist.
+- Naming asymmetry is expected and correct: `package.json` exposes
+  `./browser/mocks/<name>` and `./node/mocks/<name>`, but the specifier consumers and
+  stories use is `@storybook/nextjs-vite/<name>.mock`.
+
+## Other gotchas
+
+- Orphaned `__snapshots__/*.test.tsx.snap` files exist under some component dirs with **no**
+  sibling `*.test.tsx` source (they snapshot a `Page`, unrelated to component stories).
+  Adding stories doesn't touch them — don't "fix" them.
+- No pre-commit hook in this repo; run `pnpm check` manually before committing.


### PR DESCRIPTION
## What

Adds an `AGENTS.md` (with `CLAUDE.md` symlinked to it) capturing repo-specific guidance for coding agents.

## Why

While adding `useLinkStatus` test coverage for #121, a few non-obvious things cost time and are worth recording for future agents/contributors:

- **Wiring a Next.js mock takes five coordinated edits** (alias module, `getAlias()` in `plugin.ts` with all four `*.mock` specifiers, `tsup.config.ts` entry, `package.json` exports, changeset) — miss one and it silently won't resolve.
- **Mock-override import convention is non-obvious**: stories import spies from `@storybook/nextjs-vite/<name>.mock`, bridged by the *plugin alias* — **not** by `package.json` exports (which use the asymmetric `./browser/mocks/<name>` / `./node/mocks/<name>` names) and **not** a `./<name>.mock` subpath of this package.
- Tooling specifics (pnpm pinned, Biome `1.8.1` with `organizeImports`, `./example` is the test harness via `pnpm test:all`).
- Orphaned `__snapshots__/*.test.tsx.snap` files with no sibling test source — unrelated to component stories; documented so they aren't "fixed" by mistake.

## Notes

- Docs-only; no changeset (not user-facing).
- `CLAUDE.md` is a symlink (`120000`) → `AGENTS.md`, mirroring the convention in the main `storybook` monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)