### PR TITLE
fix: remove trailing blank line to satisfy biome formatter

### DIFF
--- a/src/plugins/next-mocks/alias/link/index.tsx
+++ b/src/plugins/next-mocks/alias/link/index.tsx
@@ -94,4 +94,3 @@ export { MockLink as Link };
 export const useLinkStatus = fn((): { pending: boolean } => ({
   pending: false,
 })).mockName("next/link::useLinkStatus");
-


### PR DESCRIPTION
## What

Removes an extra trailing blank line in `src/plugins/next-mocks/alias/link/index.tsx` that violates the Biome formatter.

## Why

The `useLinkStatus` mock addition (commit 850af4a) left a double trailing newline, causing the `Biome checks` CI job to fail on `main` and on the auto-generated "Version Packages" branch (#122). Running `biome check --write` removes the offending blank line; the full `biome check` then passes cleanly across all 96 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)