### PR TITLE
fix(next-image): hash absolute paths in virtual module IDs

### DIFF
--- a/.changeset/next-image-short-virtual-id.md
+++ b/.changeset/next-image-short-virtual-id.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-storybook-nextjs": patch
+---
+
+Fix `ENAMETOOLONG` during `storybook build` for projects with deeply nested image paths (monorepos, git worktrees, etc.). The `next-image` plugin used to embed the absolute image path as URL-safe base64 inside the virtual module ID, which made chunk filenames grow past the OS NAME_MAX limit. Virtual IDs are now short content-addressed hashes resolved through an instance-scoped lookup map, mirroring the `publicAssetUrlCache` + 8-char hash pattern in [`vitejs/vite`'s `packages/vite/src/node/plugins/asset.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/asset.ts). Also fixes the matching unit tests that were left out of sync when the IDs switched to base64, and tightens them to assert the exact path-derived hash.

--- a/src/plugins/next-image/plugin.test.ts
+++ b/src/plugins/next-image/plugin.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import path from "node:path";
 import type { NextConfigComplete } from "next/dist/server/config-shared.js";
 import type { PluginContext } from "rollup";
@@ -12,6 +13,18 @@ vi.mock("node:module", () => ({
 }));
 
 import { vitePluginNextImage } from "./plugin";
+
+const VIRTUAL_IMAGE_PREFIX = "\0virtual:next-image:";
+// `\0virtual:next-image:` (20) + 8 hex chars = 28
+const MAX_EXPECTED_ID_LENGTH = 50;
+
+function expectedId(absolutePath: string): string {
+  const hash = createHash("sha256")
+    .update(absolutePath)
+    .digest("hex")
+    .slice(0, 8);
+  return `${VIRTUAL_IMAGE_PREFIX}${hash}`;
+}
 
 describe("vitePluginNextImage resolveId", () => {
   const nextConfigResolver = {
@@ -37,10 +50,7 @@ describe("vitePluginNextImage resolveId", () => {
 
     expect(resolve).not.toHaveBeenCalled();
     expect(result).toBe(
-      `virtual:next-image?imagePath=${path.join(
-        path.dirname(importer),
-        "./images/avatar.png",
-      )}`,
+      expectedId(path.join(path.dirname(importer), "./images/avatar.png")),
     );
   });
 
@@ -60,7 +70,7 @@ describe("vitePluginNextImage resolveId", () => {
       "/project/src/Component.tsx",
       { skipSelf: true },
     );
-    expect(result).toBe(`virtual:next-image?imagePath=${resolvedPath}`);
+    expect(result).toBe(expectedId(resolvedPath));
   });
 
   it("falls back to require.resolve when Vite resolution fails", async () => {
@@ -82,6 +92,84 @@ describe("vitePluginNextImage resolveId", () => {
       "@myorg/assets/images/avatar.png",
       { paths: [path.dirname(importer.split("?")[0])] },
     );
-    expect(result).toBe(`virtual:next-image?imagePath=${resolvedPath}`);
+    expect(result).toBe(expectedId(resolvedPath));
+  });
+
+  it("produces a short, stable ID even for deeply nested monorepo paths", async () => {
+    const plugin = vitePluginNextImage(nextConfigResolver);
+    // 250+ char absolute path that would blow up the old base64 ID
+    const deepDir = `/Users/x/dev/${"nested-".repeat(30)}leaf`;
+    const importer = `${deepDir}/Component.tsx`;
+    const resolve = vi.fn();
+    const expectedImagePath = path.join(deepDir, "./images/avatar.png");
+
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    const result = await plugin.resolveId!.call(
+      createContext(resolve),
+      "./images/avatar.png",
+      importer,
+    );
+
+    expect(result).toBe(expectedId(expectedImagePath));
+    expect((result as string).length).toBeLessThanOrEqual(
+      MAX_EXPECTED_ID_LENGTH,
+    );
+
+    // Calling again with the same path is stable.
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    const second = await plugin.resolveId!.call(
+      createContext(resolve),
+      "./images/avatar.png",
+      importer,
+    );
+    expect(second).toBe(result);
+  });
+
+  it("keeps the ID safe for paths with characters Vite's decodeURI would mangle", async () => {
+    const plugin = vitePluginNextImage(nextConfigResolver);
+    // Square brackets historically broke the query-string form.
+    const importer = "/project/src/[locale]/[slug]/Component.tsx";
+    const resolve = vi.fn();
+    const expectedImagePath = path.join(
+      path.dirname(importer),
+      "./images/avatar.png",
+    );
+
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    const result = await plugin.resolveId!.call(
+      createContext(resolve),
+      "./images/avatar.png",
+      importer,
+    );
+
+    expect(result).toBe(expectedId(expectedImagePath));
+    expect(result as string).toMatch(/^\0virtual:next-image:[0-9a-f]+$/);
+  });
+
+  it("returns distinct IDs for distinct image paths", async () => {
+    const plugin = vitePluginNextImage(nextConfigResolver);
+    const importer = "/project/src/Component.tsx";
+    const resolve = vi.fn();
+
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    const a = await plugin.resolveId!.call(
+      createContext(resolve),
+      "./images/a.png",
+      importer,
+    );
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    const b = await plugin.resolveId!.call(
+      createContext(resolve),
+      "./images/b.png",
+      importer,
+    );
+
+    expect(a).toBe(
+      expectedId(path.join(path.dirname(importer), "./images/a.png")),
+    );
+    expect(b).toBe(
+      expectedId(path.join(path.dirname(importer), "./images/b.png")),
+    );
+    expect(a).not.toBe(b);
   });
 });

--- a/src/plugins/next-image/plugin.ts
+++ b/src/plugins/next-image/plugin.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import { type FilterPattern, createFilter } from "@rollup/pluginutils";
@@ -20,28 +21,22 @@ const warnOnce = (message: string) => {
 const includePattern = /\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$/;
 const excludeImporterPattern = /\.(css|scss|sass)$/;
 
-// Use null byte prefix for virtual module IDs
-// Use URL-safe base64 to encode the image path to avoid issues with special characters
-// like square brackets that are decoded by decodeURI
+// Null byte prefix marks the IDs as internal virtual modules (Rollup convention).
+// The trailing token is a short content-addressed hash of the absolute image path,
+// not the path itself, so that:
+//   * special characters in paths (square brackets, spaces, unicode) cannot leak
+//     into the ID and break Vite's decodeURI handling, and
+//   * deeply nested paths in monorepos / git worktrees do not blow up the chunk
+//     filename past the OS NAME_MAX (255) limit, which previously surfaced as
+//     ENAMETOOLONG during `storybook build`.
+// Mirrors the `publicAssetUrlCache` + 8-char hash pattern used in
+// vitejs/vite's `packages/vite/src/node/plugins/asset.ts`
+// (`__VITE_PUBLIC_ASSET__([a-z\d]{8})__`).
 const virtualImagePrefix = "\0virtual:next-image:";
-const virtualImage = "virtual:next-image";
 const virtualNextImage = "virtual:next/image";
 const virtualNextLegacyImage = "virtual:next/legacy/image";
 
-// URL-safe base64 encoding/decoding functions
-function encodeBase64Url(str: string): string {
-  const base64 = Buffer.from(str).toString("base64");
-  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
-}
-
-function decodeBase64Url(str: string): string {
-  // Add back padding if needed
-  const padding = (4 - (str.length % 4)) % 4;
-  const withPadding = str + "=".repeat(padding);
-  // Convert URL-safe base64 back to standard base64
-  const base64 = withPadding.replace(/-/g, "+").replace(/_/g, "/");
-  return Buffer.from(base64, "base64").toString();
-}
+const SHORT_HASH_LEN = 8;
 
 const require = createRequire(import.meta.url);
 
@@ -65,6 +60,28 @@ export function vitePluginNextImage(
     ],
     options.excludeFiles,
   );
+
+  // Plugin-instance-scoped lookup: short hash -> absolute image path.
+  // Lifetime is tied to a single Vite build, matching how Vite's
+  // `publicAssetUrlCache` is scoped per resolved config.
+  const imagePathByHash = new Map<string, string>();
+
+  function registerImagePath(imagePath: string): string {
+    const full = createHash("sha256").update(imagePath).digest("hex");
+    const short = full.slice(0, SHORT_HASH_LEN);
+    const existing = imagePathByHash.get(short);
+    if (existing === imagePath) {
+      return short;
+    }
+    if (existing === undefined) {
+      imagePathByHash.set(short, imagePath);
+      return short;
+    }
+    // 32-bit prefix collisions are unlikely in practice (~65k distinct image
+    // paths for a 50% chance); fall back to the full digest if we hit one.
+    imagePathByHash.set(full, imagePath);
+    return full;
+  }
 
   return {
     name: "vite-plugin-storybook-nextjs-image",
@@ -156,10 +173,7 @@ export function vitePluginNextImage(
           return null;
         }
 
-        // Use null byte prefix to embed the image path in the virtual module ID
-        // Use URL-safe base64 encoding to avoid issues with special characters like
-        // square brackets that get decoded by Vite's decodeURI
-        return `${virtualImagePrefix}${encodeBase64Url(imagePath)}`;
+        return `${virtualImagePrefix}${registerImagePath(imagePath)}`;
       }
 
       if (id === "next/image" && importer !== virtualNextImage) {
@@ -195,8 +209,12 @@ export function vitePluginNextImage(
 
       // Handle virtual image modules with null byte prefix
       if (id.startsWith(virtualImagePrefix)) {
-        // Decode the URL-safe base64 encoded image path
-        const imagePath = decodeBase64Url(id.slice(virtualImagePrefix.length));
+        const hash = id.slice(virtualImagePrefix.length);
+        const imagePath = imagePathByHash.get(hash);
+        if (imagePath === undefined) {
+          // Unknown hash — defensive fallback for IDs we did not register.
+          return null;
+        }
 
         const nextConfig = await nextConfigResolver.promise;
 


### PR DESCRIPTION
Fixes storybookjs/storybook#35874

## Summary

Replace the URL-safe base64 encoding of the absolute image path in `next-image` virtual module IDs with a short content-addressed hash, resolved through an instance-scoped lookup map.

This fixes `ENAMETOOLONG` during `storybook build` for monorepos and git worktrees, where deep paths used to inflate chunk filenames past the OS `NAME_MAX` (255) limit.

Mirrors the `publicAssetUrlCache` + 8-char hash pattern already used in [`vitejs/vite`'s `packages/vite/src/node/plugins/asset.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/asset.ts) (`__VITE_PUBLIC_ASSET__([a-z\d]{8})__`).

## What changed

`src/plugins/next-image/plugin.ts`:
- New plugin-instance-scoped `imagePathByHash: Map<string, string>`.
- `registerImagePath()` returns an 8-hex prefix of SHA-256; on the (vanishingly rare) prefix collision it falls back to the full 64-hex digest.
- `load` looks the path up by hash and returns `null` for unknown IDs.
- `encodeBase64Url` / `decodeBase64Url` are removed — nothing else uses them.

ID length stays bounded: `\0virtual:next-image:` (20) + 8 hex = 28 chars, regardless of source path depth.

## Tests

`src/plugins/next-image/plugin.test.ts`:
- Updates the three pre-existing tests that were left out of sync when IDs switched to base64 in ed88a44. (They were failing on `main` before this PR.)
- Tightens every assertion to `expect(result).toBe(expectedId(<absolutePath>))`, where `expectedId(p)` recomputes `sha256(p).slice(0,8)` — this re-establishes the path-resolution coverage the base64 form used to provide.
- Adds coverage for:
  - 250+ char absolute paths still produce a ≤50 char ID
  - Paths containing characters Vite's `decodeURI` would mangle (`[locale]/[slug]/...`) stay safe
  - Stable IDs for identical paths
  - Distinct, path-derived IDs for distinct paths

All `src/` tests pass (`vitest run src/`): 19/19. The two failing `example/` tests (`env.test.ts`, `Font.test.tsx`) were already failing on `main` and are unrelated.

`pnpm check` (biome) is clean.

## Verification in a real project

Applied this patch via `pnpm patch` to a Next.js 16 + Storybook 10.4 monorepo where `storybook build` used to fail with `ENAMETOOLONG`. After the patch (and after removing the project-local `shorten-long-chunk-names` workaround):

- `storybook build` completes.
- Max emitted `storybook-static/assets/*` basename: **59 chars** (down from 200+).
- Stories using `next/image` render identically.

## Backward compatibility

Virtual IDs are internal (`\0`-prefixed) and never referenced from userland or other plugins. No public API, type, or option changes.
