### PR TITLE
fix(next-font): support `%` in next/font/local declarations values

### DIFF
--- a/src/plugins/next-font/plugin.test.ts
+++ b/src/plugins/next-font/plugin.test.ts
@@ -1,0 +1,104 @@
+import path from "node:path";
+import type { PluginContext } from "rollup";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./local/get-font-face-declarations", () => ({
+  getFontFaceDeclarations: vi.fn(async () => ({
+    id: "font-test",
+    fontFamily: "font-test",
+    fontFaceCSS: "@font-face {}",
+    weights: ["200"],
+    styles: ["normal"],
+  })),
+}));
+
+vi.mock("./google/get-font-face-declarations", () => ({
+  getFontFaceDeclarations: vi.fn(),
+}));
+
+import { vitePluginNextFont } from "./plugin";
+
+describe("vitePluginNextFont resolveId", () => {
+  const createContext = () => ({}) as PluginContext;
+
+  it("encodes the SWC query so a `%` in font declarations cannot reach Vite's URL parser", async () => {
+    const plugin = vitePluginNextFont();
+
+    const rawQuery = JSON.stringify({
+      path: "src/fonts/Overpass.ts",
+      import: "",
+      arguments: [
+        {
+          declarations: [{ prop: "ascent-override", value: "100%" }],
+          display: "swap",
+          src: [
+            {
+              path: "./Overpass/overpass-thin.woff2",
+              style: "normal",
+              weight: "200",
+            },
+          ],
+          variable: "--font-overpass",
+        },
+      ],
+      variableName: "overpassFont",
+    });
+
+    const source = `${path.join(
+      "node_modules",
+      "next",
+      "font",
+      "local",
+      "target.css",
+    )}?${rawQuery}`;
+    const importer = "/project/.storybook/preview.tsx";
+
+    const result = (await plugin.resolveId.call(
+      createContext(),
+      source,
+      importer,
+    )) as { id: string };
+
+    expect(result).toBeDefined();
+    expect(result.id).toMatch(/^\0virtual:next-font:[A-Za-z0-9_-]+$/);
+    expect(result.id).not.toContain("%");
+  });
+
+  it("produces distinct virtual ids for different font option payloads", async () => {
+    const plugin = vitePluginNextFont();
+    const importer = "/project/.storybook/preview.tsx";
+    const sourcePrefix = path.join(
+      "node_modules",
+      "next",
+      "font",
+      "local",
+      "target.css",
+    );
+
+    const queryA = JSON.stringify({
+      path: "a.ts",
+      import: "",
+      arguments: [{ src: "./a.woff2" }],
+      variableName: "a",
+    });
+    const queryB = JSON.stringify({
+      path: "b.ts",
+      import: "",
+      arguments: [{ src: "./b.woff2" }],
+      variableName: "b",
+    });
+
+    const a = (await plugin.resolveId.call(
+      createContext(),
+      `${sourcePrefix}?${queryA}`,
+      importer,
+    )) as { id: string };
+    const b = (await plugin.resolveId.call(
+      createContext(),
+      `${sourcePrefix}?${queryB}`,
+      importer,
+    )) as { id: string };
+
+    expect(a.id).not.toEqual(b.id);
+  });
+});

--- a/src/plugins/next-font/plugin.ts
+++ b/src/plugins/next-font/plugin.ts
@@ -30,7 +30,12 @@ type FontOptions = {
 
 const includePattern = /next(\\|\/|\\\\).*(\\|\/|\\\\)target\.css\?.*$/;
 
-const virtualModuleId = "virtual:next-font";
+const virtualFontPrefix = "\0virtual:next-font:";
+
+function encodeBase64Url(str: string): string {
+  const base64 = Buffer.from(str).toString("base64");
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
 
 export function vitePluginNextFont() {
   let devMode = true;
@@ -146,16 +151,14 @@ export function vitePluginNextFont() {
       }
 
       return {
-        id: `${virtualModuleId}?${rawQuery}`,
+        id: `${virtualFontPrefix}${encodeBase64Url(rawQuery)}`,
         meta: {
           fontFaceDeclaration,
         },
       };
     },
     load(id) {
-      // Check if the file matches the specific pattern
-      const [source] = id.split("?");
-      if (source !== virtualModuleId) {
+      if (!id.startsWith(virtualFontPrefix)) {
         return undefined;
       }
 


### PR DESCRIPTION

## Summary

`next/font/local` with a `declarations` option whose value contains `%` (e.g. `value: "100%"`) failed to load. SWC encodes the font options as raw JSON in the virtual module's query string, and the unencoded `%` reached Vite's HTTP layer where `decodeURI` rejected it with `Malformed URI sequence in request URL`.

## Fix

Encoded the virtual module id with a null-byte prefix + URL-safe base64, matching the pattern already used by the `next-image` plugin in this repo for the same `decodeURI` class of issue.

- `virtual:next-font?<raw-json>` → `\0virtual:next-font:<base64>`

## Test plan

- Added `src/plugins/next-font/plugin.test.ts` with regression coverage for `%` in declarations and uniqueness of ids across payloads.
- Verified end-to-end against the reporter's repro: `Malformed URI` warning gone, virtual module now returns 200, and `@font-face` blocks include `ascent-override: 100%`.

Closes storybookjs/storybook#34847