### PR TITLE
fix: correct root require types export

### DIFF
--- a/.changeset/fix-root-require-types.md
+++ b/.changeset/fix-root-require-types.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-storybook-nextjs": patch
+---
+
+Fix the root CommonJS export's types condition to point to the emitted declaration file.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/index.d.cjs",
+        "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
     },


### PR DESCRIPTION
## Summary

- Point the root CommonJS export's `types` condition at `./dist/index.d.cts`.
- Add a patch changeset for the package metadata fix.

## Why

The published `vite-plugin-storybook-nextjs@3.3.0` tarball includes `dist/index.d.cts`, but the root `require.types` export currently points to `dist/index.d.cjs`, which is not published. The runtime CommonJS entry already points to `dist/index.cjs`, so this aligns the CommonJS declaration condition with the emitted declaration filename.

## Validation

- `node -e "const p=require('./package.json'); if(p.exports['.'].require.types!=='./dist/index.d.cts') process.exit(1); console.log('root require types ok')"`
- `git diff --check`
- Verified npm tarball evidence for `vite-plugin-storybook-nextjs@3.3.0`:
  - current `require.types: ./dist/index.d.cjs` exists: false
  - proposed `require.types: ./dist/index.d.cts` exists: true

I did not run the full `pnpm build` locally because this change is limited to package metadata and the repo's dependency install is relatively heavy in this Windows environment.