### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "vite-plugin-storybook-nextjs",
   "version": "3.3.0",
+  "bugs": {
+    "url": "https://github.com/storybookjs/vite-plugin-storybook-nextjs/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/storybookjs/vite-plugin-storybook-nextjs.git"


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.