### PR TITLE
fix: apply trailingSlash to the href rendered by the next/link mock

### DIFF
--- a/.changeset/next-link-trailing-slash.md
+++ b/.changeset/next-link-trailing-slash.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-storybook-nextjs": patch
+---
+
+Apply `trailingSlash` to the href rendered by the `next/link` mock, matching real `next/link`

--- a/src/plugins/next-mocks/alias/link/index.tsx
+++ b/src/plugins/next-mocks/alias/link/index.tsx
@@ -4,6 +4,48 @@ import { fn } from "storybook/test";
 
 const linkAction = fn().mockName("next/link::Link");
 
+// Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to every
+// href it renders. Both flags are supplied by Next's own getDefineEnv, which this plugin
+// already spreads into Vite's `define`: __NEXT_TRAILING_SLASH is `trailingSlash` and
+// __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+const removeTrailingSlash = (route: string) =>
+  route.endsWith("/") && route.length > 1 ? route.slice(0, -1) : route;
+
+const parsePath = (path: string) => {
+  const hashIndex = path.indexOf("#");
+  const queryIndex = path.indexOf("?");
+  const hasQuery = queryIndex > -1 && (hashIndex < 0 || queryIndex < hashIndex);
+
+  if (hasQuery || hashIndex > -1) {
+    return {
+      pathname: path.substring(0, hasQuery ? queryIndex : hashIndex),
+      query: hasQuery
+        ? path.substring(queryIndex, hashIndex > -1 ? hashIndex : undefined)
+        : "",
+      hash: hashIndex > -1 ? path.slice(hashIndex) : "",
+    };
+  }
+
+  return { pathname: path, query: "", hash: "" };
+};
+
+const normalizePathTrailingSlash = (path: string) => {
+  if (!path.startsWith("/") || process.env.__NEXT_MANUAL_TRAILING_SLASH) {
+    return path;
+  }
+
+  const { pathname, query, hash } = parsePath(path);
+
+  if (process.env.__NEXT_TRAILING_SLASH) {
+    if (/\.[^/]+\/?$/.test(pathname)) {
+      return `${removeTrailingSlash(pathname)}${query}${hash}`;
+    }
+    return `${pathname.endsWith("/") ? pathname : `${pathname}/`}${query}${hash}`;
+  }
+
+  return `${removeTrailingSlash(pathname)}${query}${hash}`;
+};
+
 type MockLinkProps = LinkProps &
   Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> & {
     children?: React.ReactNode;
@@ -27,7 +69,7 @@ const MockLink = React.forwardRef<HTMLAnchorElement, MockLinkProps>(
     },
     ref,
   ) {
-    const hrefString =
+    const rawHref =
       typeof href === "object"
         ? `${href.pathname || ""}${
             href.query
@@ -37,6 +79,11 @@ const MockLink = React.forwardRef<HTMLAnchorElement, MockLinkProps>(
               : ""
           }${href.hash || ""}`
         : href;
+
+    const hrefString =
+      typeof rawHref === "string"
+        ? normalizePathTrailingSlash(rawHref)
+        : rawHref;
 
     const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
       e.preventDefault();

--- a/src/plugins/next-mocks/alias/link/index.tsx
+++ b/src/plugins/next-mocks/alias/link/index.tsx
@@ -4,10 +4,12 @@ import { fn } from "storybook/test";
 
 const linkAction = fn().mockName("next/link::Link");
 
-// Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to every
-// href it renders. Both flags are supplied by Next's own getDefineEnv, which this plugin
-// already spreads into Vite's `define`: __NEXT_TRAILING_SLASH is `trailingSlash` and
-// __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+/**
+ * Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to every
+ * href it renders. Both flags are supplied by Next's own getDefineEnv, which this plugin
+ * already spreads into Vite's `define`: __NEXT_TRAILING_SLASH is `trailingSlash` and
+ * __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+ */
 const removeTrailingSlash = (route: string) =>
   route.endsWith("/") && route.length > 1 ? route.slice(0, -1) : route;
 


### PR DESCRIPTION
Follow-up to [storybookjs/storybook#35589](https://github.com/storybookjs/storybook/pull/35589), which @ndelangen asked for when merging it.

That PR fixed the `next/link` mock in `@storybook/nextjs-vite` itself, but this plugin ships its own copy at `src/plugins/next-mocks/alias/link/index.tsx` and `getAlias()` points `next/link`, `@storybook/nextjs/link.mock`, `@storybook/nextjs-vite/link.mock` and `@storybook/experimental-nextjs-vite/link.mock` at that copy. So on the Vite path the framework fix never gets loaded, and `@storybook/nextjs-vite` users still see the wrong href. This ports the same change here.

The mock renders `href` verbatim, so with `trailingSlash: true` in `next.config` a `<Link href="/about">` renders `/about` in Storybook and `/about/` in the running app. This mirrors [`next/dist/client/normalize-trailing-slash`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/normalize-trailing-slash.ts), which is what the real `<Link>` applies to every href it renders.

Both flags it reads already reach the browser through this plugin: `vitePluginNextEnv` spreads `getDefineEnv({ config: nextConfig, isClient: true, … })` into Vite's `define`, and Next emits `process.env.__NEXT_TRAILING_SLASH` from `config.trailingSlash` and `process.env.__NEXT_MANUAL_TRAILING_SLASH` from `config.skipTrailingSlashRedirect`. I checked what that produces for Next 15.5.6 — with nothing configured the first is `"false"` and the second is present with an undefined value, and Vite folds both at build time, so there is no residual `process.env` access in the bundle.

`skipTrailingSlashRedirect` is mirrored alongside `trailingSlash` because upstream treats it as a full opt-out of normalization; handling only the latter would make the mock diverge from the real `<Link>` for anyone who sets it.

### On tests

I did not add a story. `example/next.config.mjs` doesn't set `trailingSlash`, and since Vite inlines `__NEXT_TRAILING_SLASH` at build time a story can't stub it at runtime — the flag would have to be flipped for the whole example app. That would also change the `href="/about"` lines in `example/src/app/components/Link/__snapshots__/*.snap`, which `docs/agents/mocks.md` says are orphaned and shouldn't be touched.

Happy to add a story if you'd rather have one — either by flipping the example to `trailingSlash: true` and regenerating those snapshots, or by adding a second example config if that's how you'd want it isolated. Just say which.

The equivalent change on the framework side landed with unit tests covering slash appended, slash kept before query and hash, file-like paths left alone, root and already-slashed paths not doubled, the `skipTrailingSlashRedirect` opt-out, and non-absolute hrefs untouched.
