### PR TITLE
fix: replace CLAUDE.md symlink so Changesets release works

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # Agent Instructions
 
-Canonical agent guidance for `vite-plugin-storybook-nextjs`. `CLAUDE.md` symlinks here —
-keep instructions here, don't duplicate.
+Canonical agent guidance for `vite-plugin-storybook-nextjs`. `CLAUDE.md` points here — keep instructions here, don't duplicate.
 
 This plugin aliases Next.js modules to Storybook-friendly mocks so portable stories run
 under Vitest. It backs `@storybook/nextjs-vite` / `@storybook/experimental-nextjs-vite`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Summary
- The Release workflow failed after merging #136 with: `Unexpected symlink at CLAUDE.md, GitHub API only supports files and directories`
- `changesets/action` uses `commitMode: github-api`, which cannot commit git symlinks when opening the Version Packages PR
- Replace `CLAUDE.md` → `AGENTS.md` symlink with a regular `@AGENTS.md` pointer file (same pattern as the Storybook monorepo)

## Test plan
- [ ] Merge this PR
- [ ] Confirm the Release workflow on `main` succeeds and opens a Version Packages PR for the #136 changeset
- [ ] No npm publish should happen until that Version Packages PR is merged


Made with [Cursor](https://cursor.com)