### PR TITLE
Re-export next/navigation and next/router pass-through members explicitly

### DIFF
--- a/.changeset/smooth-beans-play.md
+++ b/.changeset/smooth-beans-play.md
@@ -1,0 +1,7 @@
+---
+"vite-plugin-storybook-nextjs": patch
+---
+
+Fix Next.js navigation and router mocks losing exports in dev mode
+
+A few members of `next/navigation` and `next/router` were only forwarded at runtime, so importing them by name failed in dev with "does not provide an export named". Production builds were never affected. Those members are now declared explicitly.

--- a/example/src/app/components/NavigationExports/NavigationExports.stories.tsx
+++ b/example/src/app/components/NavigationExports/NavigationExports.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, within } from "storybook/test";
+import NavigationExports from "./NavigationExports";
+
+export default {
+  component: NavigationExports,
+  parameters: {
+    layout: "centered",
+  },
+} as Meta<typeof NavigationExports>;
+
+type Story = StoryObj<typeof NavigationExports>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Smoke coverage only, not a regression test: reproducing #34688 needs the mock to go
+    // through Vite's pre-bundling, which does not happen while the plugin is workspace-
+    // linked here. That path was verified against a real install of a packed tarball.
+    await expect(
+      canvas.getByTestId("server-inserted-html-context"),
+    ).toHaveTextContent("resolved");
+    await expect(
+      canvas.getByTestId("readonly-url-search-params"),
+    ).toHaveTextContent("storybook");
+    await expect(canvas.getByTestId("redirect-type")).toHaveTextContent("push");
+  },
+};

--- a/example/src/app/components/NavigationExports/NavigationExports.tsx
+++ b/example/src/app/components/NavigationExports/NavigationExports.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import {
+  ReadonlyURLSearchParams,
+  RedirectType,
+  ServerInsertedHTMLContext,
+} from "next/navigation";
+import { useContext } from "react";
+
+/**
+ * Guards the statically analysable export surface of the `next/navigation` mock: these
+ * members are pass-throughs to Next.js' CommonJS implementation, which only `export *`
+ * covered before storybookjs/storybook#34688.
+ */
+export default function NavigationExports() {
+  const serverInsertedHTML = useContext(ServerInsertedHTMLContext);
+  const searchParams = new ReadonlyURLSearchParams(
+    new URLSearchParams("?framework=storybook"),
+  );
+
+  return (
+    <dl>
+      <dt>ServerInsertedHTMLContext</dt>
+      <dd data-testid="server-inserted-html-context">
+        {serverInsertedHTML === null ? "resolved" : "resolved (with provider)"}
+      </dd>
+
+      <dt>ReadonlyURLSearchParams</dt>
+      <dd data-testid="readonly-url-search-params">
+        {searchParams.get("framework")}
+      </dd>
+
+      <dt>RedirectType</dt>
+      <dd data-testid="redirect-type">{RedirectType.push}</dd>
+    </dl>
+  );
+}

--- a/src/plugins/next-mocks/alias/navigation/index.ts
+++ b/src/plugins/next-mocks/alias/navigation/index.ts
@@ -63,6 +63,24 @@ export const getRouter = () => {
 // re-exports of the actual module
 export * from "next/dist/client/components/navigation.js";
 
+// That module is CommonJS, so the `export *` above only exists at runtime and is invisible
+// to static ESM analysis. In dev Vite serves this mock as native ESM, where the browser
+// rejects named imports it cannot see, hence the explicit re-exports.
+// See https://github.com/storybookjs/storybook/issues/34688.
+export {
+  ReadonlyURLSearchParams,
+  RedirectType,
+  ServerInsertedHTMLContext,
+} from "next/dist/client/components/navigation.js";
+
+// Newer than our minimum supported Next.js, hence via the namespace: that keeps the export
+// statically declared but resolves to `undefined` on older releases instead of breaking
+// resolution of the whole module.
+export const forbidden: typeof actual.forbidden = actual.forbidden; // Next 15.1
+export const unauthorized: typeof actual.unauthorized = actual.unauthorized; // Next 15.1
+export const unstable_isUnrecognizedActionError: typeof actual.unstable_isUnrecognizedActionError =
+  actual.unstable_isUnrecognizedActionError; // Next 15.5
+
 // mock utilities/overrides (as of Next v14.2.0)
 export const redirect: Mock<
   (url: string, type?: actual.RedirectType) => never

--- a/src/plugins/next-mocks/alias/router/index.ts
+++ b/src/plugins/next-mocks/alias/router/index.ts
@@ -135,6 +135,10 @@ export const getRouter = () => {
 
 // re-exports of the actual module
 export * from "next/dist/client/router";
+// Same root cause as the `next/navigation` mock: `export *` from CommonJS is invisible to
+// static ESM analysis (storybookjs/storybook#34688). Only `Router` is declared in Next.js'
+// own types, the remaining runtime members stay reachable via the namespace only.
+export { Router } from "next/dist/client/router";
 export default singletonRouter;
 
 // mock utilities/overrides (as of Next v14.2.0)


### PR DESCRIPTION
Closes storybookjs/storybook#34688.

A few members of `next/navigation` and `next/router` were only forwarded to our mocks at runtime. In dev, Vite serves those mocks as native ESM, and the browser rejects named imports it cannot see up front, so any package importing one of them broke the story with "does not provide an export named". Production builds bundle differently and were never affected, which is why this only ever showed up in `storybook dev`.

Those members are now declared explicitly. The ones that only exist in newer Next.js releases resolve to `undefined` on older ones instead of breaking module resolution, so the supported range stays intact.

Verified against the reporter's reproduction with this branch installed as a real dependency: the failing story renders and the existing navigation mocks still behave. The added story is smoke coverage for the export surface, though, not a regression test - the example app links the plugin as source and never reaches the pre-bundling step that triggers the bug.

Follow-up worth considering: this pattern will keep silently dropping newly added Next.js exports. A build-time check comparing our mocks against the real modules would catch the next one for us. WDYT?
